### PR TITLE
Enhance conditional logic statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - 7.1
 - 7.2
+- 7.3
 
 before_script:
 - composer install

--- a/src/CsrfGuard.php
+++ b/src/CsrfGuard.php
@@ -200,11 +200,7 @@ class CsrfGuard
         }
 
         //if the hash of token and value are not equal
-        if (!hash_equals($tokens[$key]['value'], $value)) {
-            return false;
-        }
-
-        return true;
+        return hash_equals($tokens[$key]['value'], $value);
     }
 
     /**
@@ -218,11 +214,7 @@ class CsrfGuard
     private function tokenIsExiperd(array &$tokens, string &$key): bool
     {
         //if timed and if time is valid
-        if (isset($tokens[$key]['time']) && $tokens[$key]['time'] < time()) {
-            return false;
-        }
-
-        return true;
+        return !(isset($tokens[$key]['time']) && $tokens[$key]['time'] < time());
     }
 
     /**

--- a/tests/CsrfGuardTest.php
+++ b/tests/CsrfGuardTest.php
@@ -71,7 +71,7 @@ class CsrfGuardTest extends TestCase
      * @dataProvider contructorWrongArgumentsProvider
      *
      * @expectedException TypeError
-     * @expectedExceptionMessageRegExp /Argument 1 passed to Linna\\CsrfGuard::__construct\(\) must be of the type integer, (string|boolean|float|object|array) given/
+     * @expectedExceptionMessageRegExp /Argument 1 passed to Linna\\CsrfGuard::__construct\(\) must be of the type (int|integer), (string|bool|boolean|float|object|array) given/
      */
     public function testNewInstanceWithWrongArguments($maxStorage, $tokenStrength): void
     {
@@ -357,7 +357,7 @@ class CsrfGuardTest extends TestCase
      * Test Garbage Collector with wrong arguments.
      *
      * @expectedException TypeError
-     * @expectedExceptionMessageRegExp /Argument 1 passed to Linna\\CsrfGuard::garbageCollector\(\) must be of the type integer, boolean given/
+     * @expectedExceptionMessageRegExp /Argument 1 passed to Linna\\CsrfGuard::garbageCollector\(\) must be of the type (int|integer), (bool|boolean) given/
      *
      * @runInSeparateProcess
      */


### PR DESCRIPTION
# Changed log
- Add `php-7.3` tests in Travis CI build.
- To pass the `php-7.3` on Travis CI build, we should add possible `integer` and `boolean` type name for assert message regular expression.
- Enhance conditional statement, just return the statement without `if-else` because the statement will return the bool type directly.
- According to the [hash_equals function reference](http://php.net/manual/en/function.hash-equals.php), it will return the bool value and the `if-else` condition is unnecessary.

The latest [Travis CI build](https://travis-ci.org/linna/csrf-guard/builds/511361530) is successful.